### PR TITLE
Changed Response Channel (!) + Some makefile changes

### DIFF
--- a/API/Makefile
+++ b/API/Makefile
@@ -3,17 +3,19 @@ GOBUILD=$(GOCMD) build
 GORUN=$(GOCMD) run
 EXEC_NAME=API
 
-all: build check
+all: format check build
 run: build
 	./$(EXEC_NAME)
 
 build:
 	$(GOBUILD) -o $(EXEC_NAME)
 
-check: fmt lint vet
+#########################
+# Go Tools for formatting
+format:	fmt lint
 
-# w: writes changes to the file
-# l: list changed files
+# -w: writes changes to the file
+# -l: list changed files
 fmt:
 	gofmt -l -w *.go
 
@@ -21,8 +23,24 @@ fmt:
 lint:
 	golint -set_exit_status *.go
 
+#############################
+# Go Tools for error checking
+check: vet sql
+
 vet:
 	go vet *.go
+
+# Looks for SQL Injection weaknesses
+# -q: No output if nothing fails
+sql:
+	safesql -q .
+
+#####################################################
+# Dependencies for running the makefile
+# This does not get the dependencies for the api code
+deps:
+	go get -u golang.org/x/lint/golint
+	go get -u github.com/stripe/safesql
 
 clean:
 	rm -f $(EXEC_NAME)

--- a/API/dosages.go
+++ b/API/dosages.go
@@ -49,7 +49,7 @@ func pushDosage(r *http.Request, responseChan chan APIResponse, errorChan chan e
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusCreated}
 }

--- a/API/dosages.go
+++ b/API/dosages.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CREATE
-func pushDosage(r *http.Request, responseChan chan []byte, errorChan chan error) {
+func pushDosage(r *http.Request, responseChan chan APIResponse, errorChan chan error) {
 	vars := mux.Vars(r)
 	patientID := vars["id"]
 	dosage := Dosage{}
@@ -47,7 +47,11 @@ func pushDosage(r *http.Request, responseChan chan []byte, errorChan chan error)
 		return
 	}
 
-	errorChan <- tx.Commit()
+	if err = tx.Commit(); err != nil {
+		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
+		return		
+	}
+	responseChan <- APIResponse{nil, http.StatusCreated}
 }
 
 // RETRIEVE
@@ -55,7 +59,7 @@ func pushDosage(r *http.Request, responseChan chan []byte, errorChan chan error)
 //  Possible defaults:
 //     startDate = [current_day]
 //     endDate   = startDate + 1 month
-func getDosages(r *http.Request, responseChan chan []byte, errorChan chan error) {
+func getDosages(r *http.Request, responseChan chan APIResponse, errorChan chan error) {
 	// verify patient ?
 	vars := mux.Vars(r)
 	patientID := vars["id"]
@@ -108,13 +112,5 @@ func getDosages(r *http.Request, responseChan chan []byte, errorChan chan error)
 		errorChan <- errors.Wrap(err, "Unexpected error after scanning rows")
 		return
 	}
-
-	jsonValues, err := json.Marshal(dosages)
-	if err != nil {
-		errorChan <- errors.Wrap(err, "Unexpected error when converting to JSON")
-		return
-	}
-	responseChan <- jsonValues
-	errorChan <- nil
-	return
+	responseChan <- APIResponse{dosages, http.StatusOK}
 }

--- a/API/http.go
+++ b/API/http.go
@@ -89,38 +89,3 @@ func handlerWrapper(handler func(r *http.Request, responseChan chan []byte, erro
 		return
 	})
 }
-
-func exampleHandler(r *http.Request, responseChan chan []byte, errorChan chan error) {
-	ID := 0
-	apiToken := r.Header.Get("api_token")
-
-	// This is a join example for a patient call, change to physician it is a call only a physician can make
-	// remove join part if it is a call able for both
-	err := db.QueryRow(`SELECT id
-			   FROM Patients AS pa 
-			   INNER JOIN Accounts AS acc 
-			   ON pa.id = acc.id  
-			   WHERE acc.api_token = ?`,
-		apiToken).Scan(ID)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			errorChan <- errors.Wrap(err, "no valid login credentials")
-			return
-		}
-		errorChan <- errors.Wrap(err, "encountered error during query")
-		return
-	}
-
-	// if you are going to insert multiple things in the database do this using a transaction.
-	// see insertPatient
-
-	// do your own querries,
-	// if you encounter a "err != nil" send it to the errorChan in the above matter
-	// if all goed well, marshal your results and sen them to responseChan
-
-	// End for a get function
-	// responseChan <- "your marshalled data"
-
-	// End for a succesfull push or put function
-	// errorChan <- nil
-}

--- a/API/http.go
+++ b/API/http.go
@@ -78,7 +78,7 @@ func handlerWrapper(handler func(r *http.Request, responseChan chan APIResponse,
 				w.WriteHeader(r.StatusCode)
 				return
 			}
-			
+
 			jsonData, err := json.Marshal(r.Data)
 			if err != nil {
 				err := errors.Wrap(err, "Error during JSON Decoding")

--- a/API/notes.go
+++ b/API/notes.go
@@ -37,7 +37,7 @@ func addNote(r *http.Request, responseChan chan APIResponse, errorChan chan erro
 
 	if err = trans.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusCreated}
 }

--- a/API/patients.go
+++ b/API/patients.go
@@ -53,7 +53,7 @@ func pushPatient(r *http.Request, responseChan chan APIResponse, errorChan chan 
 	}
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusCreated}
 }
@@ -91,10 +91,10 @@ func modifyPatient(r *http.Request, responseChan chan APIResponse, errorChan cha
 		tx.Rollback()
 		return
 	}
-	
+
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusOK}
 }
@@ -172,7 +172,7 @@ func deletePatient(r *http.Request, responseChan chan APIResponse, errorChan cha
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusOK}
 }

--- a/API/physicians.go
+++ b/API/physicians.go
@@ -47,7 +47,7 @@ func pushPhysician(r *http.Request, responseChan chan APIResponse, errorChan cha
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 
 	responseChan <- APIResponse{nil, http.StatusCreated}
@@ -95,7 +95,7 @@ func modifyPhysician(r *http.Request, responseChan chan APIResponse, errorChan c
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusOK}
 }
@@ -125,7 +125,7 @@ func deletePhysician(r *http.Request, responseChan chan APIResponse, errorChan c
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusOK}
 }

--- a/API/physicians.go
+++ b/API/physicians.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CREATE
-func pushPhysician(r *http.Request, responseChan chan []byte, errorChan chan error) {
+func pushPhysician(r *http.Request, responseChan chan APIResponse, errorChan chan error) {
 	physician := Physician{}
 	dec := json.NewDecoder(r.Body)
 	err := dec.Decode(&physician)
@@ -45,12 +45,16 @@ func pushPhysician(r *http.Request, responseChan chan []byte, errorChan chan err
 		return
 	}
 
-	errorChan <- tx.Commit()
+	if err = tx.Commit(); err != nil {
+		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
+		return		
+	}
 
+	responseChan <- APIResponse{nil, http.StatusCreated}
 }
 
 // UPDATE
-func modifyPhysician(r *http.Request, responseChan chan []byte, errorChan chan error) {
+func modifyPhysician(r *http.Request, responseChan chan APIResponse, errorChan chan error) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 	physician := Physician{}
@@ -89,11 +93,15 @@ func modifyPhysician(r *http.Request, responseChan chan []byte, errorChan chan e
 		return
 	}
 
-	errorChan <- tx.Commit()
+	if err = tx.Commit(); err != nil {
+		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
+		return		
+	}
+	responseChan <- APIResponse{nil, http.StatusOK}
 }
 
 // DELETE
-func deletePhysician(r *http.Request, responseChan chan []byte, errorChan chan error) {
+func deletePhysician(r *http.Request, responseChan chan APIResponse, errorChan chan error) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 	log.Println(id)
@@ -115,5 +123,9 @@ func deletePhysician(r *http.Request, responseChan chan []byte, errorChan chan e
 		return
 	}
 
-	errorChan <- tx.Commit()
+	if err = tx.Commit(); err != nil {
+		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
+		return		
+	}
+	responseChan <- APIResponse{nil, http.StatusOK}
 }

--- a/API/structs.go
+++ b/API/structs.go
@@ -51,11 +51,13 @@ type Video struct {
 	Reference string `json:"reference"`
 }
 
+// UserValidation : ADD DOCUMENTATION
 type UserValidation struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
 
+// JWToken : ADD DOCUMENTATION
 type JWToken struct {
 	Token string `json:"token"`
 }

--- a/API/structs.go
+++ b/API/structs.go
@@ -61,3 +61,10 @@ type UserValidation struct {
 type JWToken struct {
 	Token string `json:"token"`
 }
+
+// APIResponse : Type used by the Response Channel
+// in the handlerWrapper (does not need json tags)
+type APIResponse struct {
+	Data       interface{}
+	StatusCode int
+}

--- a/API/videos.go
+++ b/API/videos.go
@@ -32,7 +32,7 @@ func addVideo(r *http.Request, responseChan chan APIResponse, errorChan chan err
 
 	if err = tx.Commit(); err != nil {
 		errorChan <- errors.Wrap(err, "Failed to commit changes to database.")
-		return		
+		return
 	}
 	responseChan <- APIResponse{nil, http.StatusCreated}
 }


### PR DESCRIPTION
I changed the response channel created in the `handlerWrapper`. It accepts an `APIResponse` struct, which contains `Data` and `StatusCode`.
* `Data` Contains the data which needs to be Marshalled and returned to the request. Note that the data is Marshalled in the handlerWrapper instead of in every separate function (I would assume this is a better practice).
* `StatusCode` Contains the response status code for the request. For example it contains a `http.StatusCreated` when something is successfully created.

It might be best not to 'just' accept and merge this PR without looking at the changes. I think I changed all the functions to work correctly, however I was not too sure about the `login` and `authentication` functions, since they do not follow the 'normal' pattern of our api functions. 

What I tested seemed to work, but I did not extensively test wrong/invalid requests.